### PR TITLE
Ignore IDE inspection profiles in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,4 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
-.idea/inspectionProfiles/profiles_settings.xml
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+.idea/inspectionProfiles/profiles_settings.xml


### PR DESCRIPTION
Added .idea/inspectionProfiles/profiles_settings.xml to .gitignore to prevent IDE-specific configuration files from being tracked in version control.